### PR TITLE
Fix path normalization for Windows drive letters

### DIFF
--- a/src/strip-method-bodies.ts
+++ b/src/strip-method-bodies.ts
@@ -83,10 +83,6 @@ function normalizeFilePath(filePath: string): string {
     filePath = path.resolve(process.cwd(), filePath);
   }
 
-  // 处理 Windows 盘符路径（如 C:/path/to/file）
-  if (/^[a-zA-Z]:/.test(filePath)) {
-    filePath = filePath.replace(/^[a-zA-Z]:/, '');
-  }
 
   // 处理 UNC 路径（如 //server/share/path）
   if (filePath.startsWith('//')) {


### PR DESCRIPTION
## Summary
- remove Windows drive letter stripping logic to preserve valid file paths

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684390ae052c832da5557f8dc3b06850