### PR TITLE
Fix locateFile for web-tree-sitter

### DIFF
--- a/src/strip-method-bodies.ts
+++ b/src/strip-method-bodies.ts
@@ -9,7 +9,11 @@ const languageCache: Record<string, any> = {};
 
 export async function init() {
   if (!parserReady) {
-    await Parser.init();
+    await Parser.init({
+      locateFile(scriptName: string) {
+        return require.resolve(`web-tree-sitter/${scriptName}`);
+      }
+    });
     // Preload all supported languages
     for (const [ext, entry] of Object.entries(languageWasmMap)) {
       try {


### PR DESCRIPTION
## Summary
- initialize `web-tree-sitter` with `locateFile` so the wasm can be found

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684394aec958832d9f5b8f1fd9e656f5